### PR TITLE
Change where IQMs are stored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Flywheel <support@flywheel.io>
 
 RUN apt-get update && apt-get install -y zip && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g bids-validator@1.5.7
+RUN npm install -g bids-validator@1.9.9
 
 COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt && \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Gear that runs the [MRIQC](https://mriqc.readthedocs.io/en/stable/about.html) pi
 
 MRIQC calculates [Image Quality Metrics (IQMs)](https://mriqc.readthedocs.io/en/stable/measures.html#module-mriqc.qc) and saves them as JSON files and in HTML reports.
 
-This gear runs poldracklab/mriqc version 0.15.3 (April 6, 2020) and bids-standard/bids-validator version 1.5.7 (September 18, 2020).
+This gear runs poldracklab/mriqc version 0.15.2 (April 6, 2020) and bids-standard/bids-validator version 1.5.7 (September 18, 2020).
 
 This can run at the
 [project](https://docs.flywheel.io/hc/en-us/articles/360017808354-EM-6-1-x-Release-Notes),
@@ -15,8 +15,10 @@ the BIDS formatted data directly at the given run level.
 
 For configuration options, please see [MRIQC command line interface](https://mriqc.readthedocs.io/en/stable/running.html#command-line-interface).  Note that arguments such as --n_procs --mem_gb and --ants-nthreads are set to use the maximum available as detected by MRIQC.
 
+IQMs will be reported under the file.info.IQM field.
+
 This will create a zip archive for each individual html file to allow quick
-on-platform viewing: a click on the .html.zip file opens it an a new
+on-platform viewing: a click on the .html.zip file opens it in a new
 browser tab.  Note that links in the html files will not work and
 clicking on .html files directly will not display them properly.
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,3 +1,6 @@
+##1.2.4_0.15.2
+* CHANGE: IQM metadata stored as a list under info.IQM, rather than under info.<filename>
+
 ##1.2.2_0.15.2
 * Update the URL to GitLab
 

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
         }
     },
     "inputs": {
-        "key": {
+        "api-key": {
             "base": "api-key",
             "read-only": true
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flywheel-sdk~=14.3.2
-psutil~=5.6.3
-flywheel-gear-toolkit~=0.1.1
+flywheel-gear-toolkit[sdk]==0.*,>=0.6.10
+fw-client==0.*,>=0.3.1
+psutil==5.*,>=5.6.3

--- a/run.py
+++ b/run.py
@@ -30,6 +30,7 @@ from utils.results.zip_intermediate import (
     zip_intermediate_selected,
 )
 from utils.singularity import run_in_tmp_dir
+
 # from utils.singularity import (
 #     check_for_singularity,
 #     log_singularity_details,
@@ -87,7 +88,7 @@ def set_performance_config(config):
         config["n_cpus"] = os_cpu_count  # zoom zoom
         log.info("using n_cpus = %d (maximum available)", os_cpu_count)
 
-    psutil_mem_gb = int(psutil.virtual_memory().available / (1024**3))
+    psutil_mem_gb = int(psutil.virtual_memory().available / (1024 ** 3))
     log.info("psutil.virtual_memory().available= {:5.2f} GiB".format(psutil_mem_gb))
     mem_gb = config.get("mem_gb")
     if mem_gb:
@@ -300,11 +301,7 @@ def main(gtk_context):
 
             # This is what it is all about
             exec_command(
-                command,
-                environ=environ,
-                dry_run=dry_run,
-                shell=True,
-                cont_output=True,
+                command, environ=environ, dry_run=dry_run, shell=True, cont_output=True,
             )
 
             # Harvest first level jsons into group level analysis
@@ -458,7 +455,7 @@ if __name__ == "__main__":
     # use_singularity = check_for_singularity()
     # To test within a Singularity container, use "(config_path='/flywheel/v0/config.json')" for context.
 
-    #move the singularity check inside one level where the centext is available to check which directory should be made /tmp
+    # move the singularity check inside one level where the centext is available to check which directory should be made /tmp
     with flywheel_gear_toolkit.GearToolkitContext() as context:
         scratch_dir = run_in_tmp_dir(context.config["gear-writable-dir"])
 

--- a/tests/bin/pack-gear-tests.py
+++ b/tests/bin/pack-gear-tests.py
@@ -22,7 +22,6 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 
 def main():
-
     exit_code = 0
 
     # This can be run from:
@@ -54,12 +53,10 @@ def main():
         tests = [args.test]
 
     for test in tests:
-
         if test[-1] == "/":
             test = test[:-1]
 
         if Path(test).is_dir():
-
             name = test + ".zip"
             if args.verbose > 0:
                 print(f'"{test}" --> "{name}"')
@@ -90,7 +87,6 @@ def main():
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/tests/bin/unpack-gear-tests.py
+++ b/tests/bin/unpack-gear-tests.py
@@ -17,7 +17,6 @@ from zipfile import ZipFile
 
 
 def main():
-
     exit_code = 0
 
     # This can be run from:
@@ -47,7 +46,6 @@ def main():
         tests = [args.test]
 
     for test in tests:
-
         name = test[:-4]
         if args.verbose > 0:
             print(f'"{test}" --> "{name}"')
@@ -63,7 +61,6 @@ def main():
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/tests/integration_tests/test_dry_run.py
+++ b/tests/integration_tests/test_dry_run.py
@@ -24,7 +24,6 @@ def test_dry_run_works(
     search_sysout,
     search_syserr,
 ):
-
     user_json = Path("/home/bidsapp/.config/flywheel/user.json")
     if not user_json.exists():
         TestCase.skipTest("", f"No API key available in {str(user_json)}")
@@ -32,7 +31,6 @@ def test_dry_run_works(
     install_gear("dry_run.zip")
 
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
-
         status = run.main(gtk_context)
 
     captured = capfd.readouterr()

--- a/tests/integration_tests/test_wet_run.py
+++ b/tests/integration_tests/test_wet_run.py
@@ -17,9 +17,11 @@ import run
 
 
 def test_wet_run_fails(
-    capfd, install_gear, print_captured, search_stderr_contains,
+    capfd,
+    install_gear,
+    print_captured,
+    search_stderr_contains,
 ):
-
     user_json = Path("/home/bidsapp/.config/flywheel/user.json")
     if not user_json.exists():
         TestCase.skipTest("", f"No API key available in {str(user_json)}")
@@ -27,15 +29,17 @@ def test_wet_run_fails(
     install_gear("wet_run.zip")
 
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
-
         print("client is ", gtk_context.client)
         status = run.main(gtk_context)
 
     captured = capfd.readouterr()
     print_captured(captured)
 
-    assert search_stderr_contains(captured, "Empty file",
-                                  "sub-TOME3024_ses-Session1_task-REST_dir-AP_run-2_bold.nii.gz")
+    assert search_stderr_contains(
+        captured,
+        "Empty file",
+        "sub-TOME3024_ses-Session1_task-REST_dir-AP_run-2_bold.nii.gz",
+    )
     assert status == 1
     assert Path("/flywheel/v0/output/.metadata.json").exists()
     assert search_stderr_contains(captured, "CRITICAL", "command has failed")

--- a/tests/integration_tests/test_wet_run.py
+++ b/tests/integration_tests/test_wet_run.py
@@ -17,10 +17,7 @@ import run
 
 
 def test_wet_run_fails(
-    capfd,
-    install_gear,
-    print_captured,
-    search_stderr_contains,
+    capfd, install_gear, print_captured, search_stderr_contains,
 ):
     user_json = Path("/home/bidsapp/.config/flywheel/user.json")
     if not user_json.exists():

--- a/tests/unit_tests/test_download_run_level.py
+++ b/tests/unit_tests/test_download_run_level.py
@@ -69,7 +69,6 @@ def test_fix_dataset_description_fixes(tmp_path, caplog):
 
 
 def test_fix_dataset_description_missing_creates(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     bids_path = tmp_path
@@ -102,19 +101,17 @@ class Acquisition:
 
 
 def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch("utils.bids.download_run_level.download_bids_dir"):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=[], gear_path=tmp_path
                 )
@@ -140,21 +137,19 @@ def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
 
 
 def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "no_destination"
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch("utils.bids.download_run_level.download_bids_dir"):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=[], gear_path=tmp_path
                 )
@@ -176,7 +171,6 @@ def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
 
 
 def test_download_bids_for_runlevel_project_works(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "project"
@@ -188,18 +182,17 @@ def test_download_bids_for_runlevel_project_works(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -222,7 +215,6 @@ def test_download_bids_for_runlevel_project_works(tmp_path, caplog):
 
 
 def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "subject"
@@ -234,18 +226,17 @@ def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:bad_destination"], gear_path=tmp_path
                 )
@@ -268,7 +259,6 @@ def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
 
 
 def test_download_bids_for_runlevel_unknown_acqusition_detected(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     hierarchy = copy.deepcopy(HIERARCHY)
@@ -281,18 +271,17 @@ def test_download_bids_for_runlevel_unknown_acqusition_detected(tmp_path, caplog
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -312,7 +301,6 @@ def test_download_bids_for_runlevel_unknown_acqusition_detected(tmp_path, caplog
 
 
 def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "session"
@@ -324,18 +312,17 @@ def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -357,22 +344,20 @@ def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
 
 
 def test_download_bids_for_runlevel_acquisition_exception_detected(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "utils.bids.download_run_level.download_bids_dir",
             side_effect=flywheel.ApiException("foo", "fum"),
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -392,7 +377,6 @@ def test_download_bids_for_runlevel_acquisition_exception_detected(tmp_path, cap
 
 
 def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "who knows"
@@ -404,13 +388,13 @@ def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
-            "utils.bids.download_run_level.validate_bids", return_value=0,
+            "utils.bids.download_run_level.validate_bids",
+            return_value=0,
         ):
-
             gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                 input_args=["-d aex:analysis"], gear_path=tmp_path
             )
@@ -434,7 +418,6 @@ def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
 def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
     tmp_path, caplog
 ):
-
     caplog.set_level(logging.DEBUG)
 
     ## create expected file
@@ -444,18 +427,17 @@ def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
     #    json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "utils.bids.download_run_level.download_bids_dir",
             side_effect=BIDSExportError("crash", "boom"),
         ):
-
             with patch(
-                "utils.bids.download_run_level.validate_bids", return_value=0,
+                "utils.bids.download_run_level.validate_bids",
+                return_value=0,
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -475,7 +457,6 @@ def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
 
 
 def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "project"
@@ -487,19 +468,17 @@ def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
-
             with patch(
                 "utils.bids.download_run_level.validate_bids",
                 side_effect=Exception("except", "what"),
             ):
-
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
                 )
@@ -521,20 +500,18 @@ def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog
 
 
 def test_download_bids_for_runlevel_nothing_downloaded_detected(tmp_path, caplog):
-
     caplog.set_level(logging.DEBUG)
 
     HIERARCHY["run_level"] = "subject"
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client",
+        return_value=Acquisition(),
     ):
-
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value="nowhere",
         ):
-
             gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                 input_args=["-d aex:analysis"], gear_path=tmp_path
             )

--- a/tests/unit_tests/test_download_run_level.py
+++ b/tests/unit_tests/test_download_run_level.py
@@ -104,13 +104,11 @@ def test_download_bids_for_runlevel_acquisition_works(tmp_path, caplog):
     caplog.set_level(logging.DEBUG)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch("utils.bids.download_run_level.download_bids_dir"):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=[], gear_path=tmp_path
@@ -142,13 +140,11 @@ def test_download_bids_for_runlevel_no_destination_complains(tmp_path, caplog):
     HIERARCHY["run_level"] = "no_destination"
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch("utils.bids.download_run_level.download_bids_dir"):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=[], gear_path=tmp_path
@@ -182,16 +178,14 @@ def test_download_bids_for_runlevel_project_works(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -226,16 +220,14 @@ def test_download_bids_for_runlevel_bad_destination_noted(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:bad_destination"], gear_path=tmp_path
@@ -271,16 +263,14 @@ def test_download_bids_for_runlevel_unknown_acqusition_detected(tmp_path, caplog
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -312,16 +302,14 @@ def test_download_bids_for_runlevel_session_works(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
             return_value=bids_path,
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -347,16 +335,14 @@ def test_download_bids_for_runlevel_acquisition_exception_detected(tmp_path, cap
     caplog.set_level(logging.DEBUG)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "utils.bids.download_run_level.download_bids_dir",
             side_effect=flywheel.ApiException("foo", "fum"),
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -388,12 +374,10 @@ def test_download_bids_for_runlevel_unknown_detected(tmp_path, caplog):
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
-            "utils.bids.download_run_level.validate_bids",
-            return_value=0,
+            "utils.bids.download_run_level.validate_bids", return_value=0,
         ):
             gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                 input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -427,16 +411,14 @@ def test_download_bids_for_runlevel_bidsexporterror_exception_detected(
     #    json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "utils.bids.download_run_level.download_bids_dir",
             side_effect=BIDSExportError("crash", "boom"),
         ):
             with patch(
-                "utils.bids.download_run_level.validate_bids",
-                return_value=0,
+                "utils.bids.download_run_level.validate_bids", return_value=0,
             ):
                 gtk_context = flywheel_gear_toolkit.GearToolkitContext(
                     input_args=["-d aex:analysis"], gear_path=tmp_path
@@ -468,8 +450,7 @@ def test_download_bids_for_runlevel_validate_exception_detected(tmp_path, caplog
         json.dump(DATASET_DESCRIPTION, jfp)
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",
@@ -505,8 +486,7 @@ def test_download_bids_for_runlevel_nothing_downloaded_detected(tmp_path, caplog
     HIERARCHY["run_level"] = "subject"
 
     with patch(
-        "flywheel_gear_toolkit.GearToolkitContext.client",
-        return_value=Acquisition(),
+        "flywheel_gear_toolkit.GearToolkitContext.client", return_value=Acquisition(),
     ):
         with patch(
             "flywheel_gear_toolkit.GearToolkitContext.download_project_bids",

--- a/tests/unit_tests/test_generate_command.py
+++ b/tests/unit_tests/test_generate_command.py
@@ -10,7 +10,6 @@ from run import generate_command
 def test_generate_command_missing_config_works(
     capfd, print_captured, search_stdout_contains
 ):
-
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
         gtk_context.init_logging("info")
         gtk_context.log_config()
@@ -38,7 +37,7 @@ def test_generate_command_missing_config_works(
         errors = []
         warnings = []
 
-        generate_command(config, Path("work"), Path("out/###"), log, errors, warnings)
+        generate_command(config, Path("work"), Path("out/###"), errors, warnings)
 
     captured = capfd.readouterr()
 

--- a/tests/unit_tests/test_run_level.py
+++ b/tests/unit_tests/test_run_level.py
@@ -216,14 +216,12 @@ def test_run_level_unknown_project_says_so(caplog):
 
 
 def test_run_level_exception_handled(caplog):
-
     caplog.set_level(logging.DEBUG)
 
     with patch(
         "flywheel.Client.get",
         MagicMock(side_effect=flywheel.ApiException("foo", "fum")),
     ):
-
         fw = flywheel.Client
 
         hierarchy = get_run_level_and_hierarchy(fw, "01234")

--- a/tests/unit_tests/test_set_performance_config.py
+++ b/tests/unit_tests/test_set_performance_config.py
@@ -40,15 +40,13 @@ def search_stdout_contains(captured, find_me, contains_me):
 
 
 def test_set_performance_config_0_is_max(capfd):
-
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
         gtk_context.init_logging("info")
         gtk_context.log_config()
-        log = gtk_context.log
 
         config = {"n_cpus": 0, "mem_gb": 0}
 
-        set_performance_config(config, log)
+        set_performance_config(config)
 
     print("config = ", json.dumps(config, indent=4))
 
@@ -61,15 +59,13 @@ def test_set_performance_config_0_is_max(capfd):
 
 
 def test_set_performance_config_2much_is_2much(capfd):
-
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
         gtk_context.init_logging("info")
         gtk_context.log_config()
-        log = gtk_context.log
 
         config = {"n_cpus": 10001, "mem_gb": 10001}
 
-        set_performance_config(config, log)
+        set_performance_config(config)
 
     print("config = ", json.dumps(config, indent=4))
 
@@ -82,15 +78,13 @@ def test_set_performance_config_2much_is_2much(capfd):
 
 
 def test_set_performance_config_default_is_max(capfd):
-
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
         gtk_context.init_logging("info")
         gtk_context.log_config()
-        log = gtk_context.log
 
         config = {}
 
-        set_performance_config(config, log)
+        set_performance_config(config)
 
     print("config = ", json.dumps(config, indent=4))
 
@@ -103,15 +97,13 @@ def test_set_performance_config_default_is_max(capfd):
 
 
 def test_set_performance_config_1_is_1(capfd):
-
     with flywheel_gear_toolkit.GearToolkitContext(input_args=[]) as gtk_context:
         gtk_context.init_logging("info")
         gtk_context.log_config()
-        log = gtk_context.log
 
         config = {"n_cpus": 1, "mem_gb": 1}
 
-        set_performance_config(config, log)
+        set_performance_config(config)
 
     print("config = ", json.dumps(config, indent=4))
 

--- a/tests/unit_tests/test_store_iqms.py
+++ b/tests/unit_tests/test_store_iqms.py
@@ -2,8 +2,7 @@ import logging
 from unittest import mock
 from unittest.mock import patch
 
-
-from utils.results.store_iqms import store_iqms, _create_nested_metadata
+from utils.results.store_iqms import _create_nested_metadata, store_iqms
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +19,7 @@ class TestStoreIQMs:
 
         caplog.clear()
         caplog.set_level(logging.DEBUG)
-        store_iqms( "foo_dir")
+        store_iqms("foo_dir")
         assert len(caplog.records) == 2
         assert "Did not find MRIQC output" in caplog.records[0].message
         assert mock_nested.call_count == 0

--- a/tests/unit_tests/test_validate.py
+++ b/tests/unit_tests/test_validate.py
@@ -23,7 +23,6 @@ def json_file():
 
 
 def test_validate_bids_basic_results_works(caplog, tmp_path, json_file):
-
     caplog.set_level(logging.DEBUG)
 
     bids_path = Path("work/bids")
@@ -48,7 +47,6 @@ def test_validate_bids_basic_results_works(caplog, tmp_path, json_file):
             with patch(
                 "utils.bids.validate.json.load", MagicMock(side_effect=[bids_output])
             ):
-
                 mock_run.return_value = ret
 
                 err_code = validate_bids(bids_path)
@@ -59,7 +57,6 @@ def test_validate_bids_basic_results_works(caplog, tmp_path, json_file):
 
 
 def test_validate_bids_no_bids_output(caplog, tmp_path, json_file):
-
     caplog.set_level(logging.DEBUG)
 
     bids_path = Path("work/bids")
@@ -76,7 +73,6 @@ def test_validate_bids_no_bids_output(caplog, tmp_path, json_file):
     with patch("utils.bids.validate.sp.run") as mock_run:
         with patch("__main__.open", MagicMock()):
             with patch("utils.bids.validate.json.load", MagicMock(side_effect=[""])):
-
                 mock_run.return_value = ret
 
                 err_code = validate_bids(bids_path)
@@ -103,7 +99,6 @@ def test_validate_bids_non_zero_exit_reported(caplog, tmp_path, json_file):
     chdir(str(tmp_path))
 
     with patch("utils.bids.validate.sp.run") as mock_run:
-
         mock_run.return_value = ret
 
         err_code = validate_bids(bids_path)
@@ -114,7 +109,6 @@ def test_validate_bids_non_zero_exit_reported(caplog, tmp_path, json_file):
 
 
 def test_validate_bids_error_results_exception(caplog, tmp_path, json_file):
-
     caplog.set_level(logging.DEBUG)
 
     bids_path = Path("work/bids")
@@ -139,7 +133,6 @@ def test_validate_bids_error_results_exception(caplog, tmp_path, json_file):
             with patch(
                 "utils.bids.validate.json.load", MagicMock(side_effect=[bids_output])
             ):
-
                 mock_run.return_value = ret
 
                 err_code = validate_bids(bids_path)

--- a/utils/bids/download_run_level.py
+++ b/utils/bids/download_run_level.py
@@ -56,15 +56,12 @@ def fix_dataset_description(bids_path):
     need_to_write = False
 
     if validator_file.exists():
-
         with open(validator_file) as json_file:
-
             data = json.load(json_file)
 
             log.info("type of Funding is: %s", str(type(data["Funding"])))
 
             if not isinstance(data["Funding"], list):
-
                 log.warning('data["Funding"] is not a list')
                 data["Funding"] = list(data["Funding"])
                 log.info("changed it to: %s", str(type(data["Funding"])))
@@ -154,7 +151,6 @@ def download_bids_for_runlevel(
         err_code = 24  # destination does not exist
 
     else:
-
         if gtk_context.destination["type"] == "analysis":
             pass
 
@@ -176,7 +172,6 @@ def download_bids_for_runlevel(
             )
 
         try:  # download BIDS data for the proper run level
-
             if src_data:
                 log.info("Downloading source data.")
             else:
@@ -197,7 +192,6 @@ def download_bids_for_runlevel(
             bids_dir = Path(gtk_context.work_dir) / "bids"
 
             if run_level == "project":
-
                 log.info(
                     'Downloading BIDS for project "%s"', hierarchy["project_label"]
                 )
@@ -212,7 +206,6 @@ def download_bids_for_runlevel(
                     )
 
             elif run_level == "subject":
-
                 log.info(
                     'Downloading BIDS for subject "%s"', hierarchy["subject_label"]
                 )
@@ -230,7 +223,6 @@ def download_bids_for_runlevel(
                     )
 
             elif run_level == "session":
-
                 log.info(
                     'Downloading BIDS for session "%s"', hierarchy["session_label"]
                 )
@@ -249,7 +241,6 @@ def download_bids_for_runlevel(
                     )
 
             elif run_level == "acquisition":
-
                 if hierarchy["acquisition_label"] == "unknown acquisition":
                     msg = (
                         'Cannot download BIDS for acquisition "'
@@ -307,7 +298,6 @@ def download_bids_for_runlevel(
             err_code = 25  # download_bids_dir() ApiException
 
     if bids_path:  # then validate it
-
         if Path(bids_path).exists():
             log.info("Found BIDS path %s", str(bids_path))
 

--- a/utils/bids/tree.py
+++ b/utils/bids/tree.py
@@ -39,7 +39,6 @@ def tree_bids(directory, base_name, title=None, extra=None):
         title = ""
 
     with open(base_name + ".html", "w") as html_file:
-
         html1 = (
             '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 '
             'Transitional//EN">\n'
@@ -72,7 +71,6 @@ def tree_bids(directory, base_name, title=None, extra=None):
         num_files = 0
 
         for path in sorted(directory.rglob("*")):
-
             depth = len(path.relative_to(directory).parts)
             spacer = "    " * depth
 

--- a/utils/bids/validate.py
+++ b/utils/bids/validate.py
@@ -176,6 +176,7 @@ def validate_bids(bids_path):
 
     except TypeError as ter:
         log.critical(str(repr(ter)), exc_info=True)
+        log.debug(f"bids_output: {bids_output}")
         err_code = 12
 
     if num_bids_errors < 0:

--- a/utils/dry_run.py
+++ b/utils/dry_run.py
@@ -4,6 +4,8 @@ import logging
 import os
 from pathlib import Path
 
+from flywheel_gear_toolkit.interfaces.command_line import exec_command
+
 log = logging.getLogger(__name__)
 
 
@@ -68,3 +70,13 @@ def pretend_it_ran(context):
     with open(ff, "w") as fp:
         fp.write(html)
     log.debug("Creating: " + ff)
+
+    log.info("Creating fake output in " + path)
+    path = "output/" + context.destination["id"] + "/"
+    if os.path.exists(path):
+        log.info("path already exists: " + path)
+    else:
+        os.makedirs(path)
+    os.chdir(path)
+    cmd = ["unzip", "-o", "../../tests/data/gear_tests/dry_run_data.zip"]
+    exec_command(cmd, environ=os.environ, cont_output=True)

--- a/utils/fly/dev_helpers.py
+++ b/utils/fly/dev_helpers.py
@@ -1,6 +1,8 @@
-from os import walk, path
 import json
 import logging
+from os import path, walk
+
+from flywheel_gear_toolkit import GearToolkitContext
 
 log = logging.getLogger(__name__)
 

--- a/utils/results/store_iqms.py
+++ b/utils/results/store_iqms.py
@@ -1,14 +1,50 @@
 import json
 import logging
 import os.path as op
-import glob
+from collections import defaultdict
+from pathlib import Path
+
+import flywheel
 
 from utils.fly.dev_helpers import determine_dir_structure
 
 log = logging.getLogger(__name__)
 
 
-def store_iqms(output_analysis_id_dir):
+def find_bids_acqs(context):
+    """Search acquisitions for BIDS-related acquisitions.
+    Returns list of acquisition objects.
+    """
+    fw = flywheel.Client(context.get_input("api-key")["key"])
+    dest_id = context.destination["id"]
+    destination = fw.get(dest_id)
+    session = fw.get_session(destination.parents["session"])
+    bids_acqs = []
+    # TODO figure out how to get the right type that iter_find can operate on, not obj
+    for acq in session.acquisitions.iter_find():
+        for f in acq.files:
+            if f.info.get("BIDS"):
+                bids_acqs.append(acq)
+    return bids_acqs
+
+
+def find_fw_file(bids_name, acqs: list):
+    """
+    Args:
+        bids_name (str): most of the filename that needs to match the BIDS filename in BIDS.info
+        acqs (list): List of fw acquisition objects
+    Returns:
+        acquisition and file objects matching the original image file on which the
+        metrics were completed.
+
+    """
+    for acq in acqs:
+        for f in acq.files:
+            if bids_name in f.info.get("BIDS").get("Filename") and "nii" in f.name:
+                return acq, f
+
+
+def store_iqms(output_analysis_id_dir, context):
     """
     MRIQC calculates 56 anatomical features and numerous functional
     features to characterize quality. These features are called Image
@@ -17,18 +53,24 @@ def store_iqms(output_analysis_id_dir):
     for inclusion on the "Custom Information" tab as a table.
     Args:
         output_analysis_id_dir (filepath): output file structure ending with output > destination_id
+        context (GearToolkitContext): Gear Context for writing metadata to source output_files.
     Returns
         nested dict to add to metadata.json
     """
-
-    metadata = {}
-    metadata.setdefault("analysis", {}).setdefault("info", {})
-    files = _find_files(output_analysis_id_dir, "json")
-    if files:
-        for analysis in files:
+    # MRIqc output is stored as json
+    output_files = _find_output_files(output_analysis_id_dir, "json")
+    bids_acqs = find_bids_acqs(context)
+    # Create dictionary, in case metadata is not able to be posted directly to
+    # the corresponding file. Note: I can't really think of a time that this is
+    # the case. `dataset_description` should be found by the search nor needed
+    # as an analysis file to update, so the else loop may not be needed.
+    metadata_for_upload = defaultdict()
+    if output_files:
+        for analysis in output_files:
+            log.debug(f"Parsing {analysis}")
             with open(analysis) as f:
-                analysis_to_parse = json.loads(f.read())
                 try:
+<<<<<<< HEAD
                     name_object = op.basename(analysis).split("_")
 
                     # remove subject key-value pair
@@ -41,12 +83,35 @@ def store_iqms(output_analysis_id_dir):
                     metadata["analysis"]["info"][
                         f"{name_object}"
                     ] = _create_nested_metadata(analysis_to_parse)
+=======
+                    data_to_parse = json.loads(f.read())
+>>>>>>> fw/main
                 except json.decoder.JSONDecodeError:
                     log.info(f"{analysis} was empty")
-    return metadata
+                    continue
+            # Find parent and file in Flywheel based on bids name
+            #   How to find will depend on destination parent, project, subject or session.
+            parent, fw_file = find_fw_file(
+                op.splitext(op.basename(analysis))[0], bids_acqs
+            )
+            if fw_file:
+                # B/c of 'info' being a flywheel.models.info_list_output.InfoListOutput,
+                # deep_merge in `update_file` doesn't work.
+                fw_file.update_info({"IQM": _create_nested_metadata(data_to_parse)})
+                log.info(f"Updated {fw_file.name}")
+            else:
+                # If file wasn't found in Flywheel (mostly only dataset description)
+                update_dict = _create_nested_metadata(data_to_parse)
+                update_dict["filename"] = op.splitext(op.basename(analysis))[0]
+                metadata_for_upload["analysis"]["info"]["IQM"].append(update_dict)
+
+    if metadata_for_upload:
+        return metadata_for_upload
+    else:
+        return None
 
 
-def _find_files(output_analysis_id_dir, ext):
+def _find_output_files(output_analysis_id_dir, ext):
     """
     Locates analysis output. Assumes naming scheme follows BIDS format.
         output_analysis_id_dir (path): path including the destination id for project
@@ -60,9 +125,13 @@ def _find_files(output_analysis_id_dir, ext):
         path or see if the analysis was not completed.
     """
     try:
-        files = glob.glob(op.join(output_analysis_id_dir, "**/*" + ext), recursive=True)
+        files = [
+            f
+            for f in Path(output_analysis_id_dir).rglob("**/*" + ext)
+            if not op.basename(f).startswith("._")
+        ]
         files[0]  # Throw exception if empty list
-        list_of_files = "\n  ".join(files)
+        list_of_files = "\n  ".join([str(f) for f in files])
         log.info(f"Found IQM files:\n  {list_of_files}")
         return files
     except IndexError:
@@ -70,25 +139,26 @@ def _find_files(output_analysis_id_dir, ext):
         log.debug(determine_dir_structure(output_analysis_id_dir))
 
 
-def _create_nested_metadata(analysis_to_parse):
+def _create_nested_metadata(data_to_parse):
     """
     Sift through the json files that correspond with different types of scans. Keep the
     fields associated with IQMs for MRIQC. Reorder the fields for export to metadata.json
     Args:
-        analysis_to_parse (dict): converted from original analyses' output json summaries
+        data_to_parse (dict): converted from original analyses' output json summaries
     Returns:
-        add_metadata (nested dict): dictionary to append to metadata under the analysis >
+        add_metadata (dict): dictionary to append to metadata under the analysis >
         info > sorting_classifier (filename) entry
     """
 
-    toss_keys = [k for k in analysis_to_parse.keys() if k.startswith("__")]
-    toss_keys.extend(["bids_meta", "provenance", "bids_name"])
+    toss_keys = [k for k in data_to_parse.keys() if k.startswith("__")]
+    toss_keys.extend(["bids_meta", "provenance"])
 
     add_metadata = {}
 
-    for k, v in analysis_to_parse.items():
+    for k, v in data_to_parse.items():
         if k not in toss_keys:
             add_metadata[k] = v
+    # Should be roughly 68 metrics. See https://mriqc.readthedocs.io/en/latest/measures.html
     log.debug(f"Passing {len(add_metadata)} IQM items to metadata.")
     return add_metadata
 

--- a/utils/results/store_iqms.py
+++ b/utils/results/store_iqms.py
@@ -70,22 +70,7 @@ def store_iqms(output_analysis_id_dir, context):
             log.debug(f"Parsing {analysis}")
             with open(analysis) as f:
                 try:
-<<<<<<< HEAD
-                    name_object = op.basename(analysis).split("_")
-
-                    # remove subject key-value pair
-                    name_object = [item for item in name_object if "sub-" not in item]
-
-                    #remove session key-value pair
-                    name_object = [item for item in name_object if "ses-" not in item]
-
-                    name_object = "_".join(name_object)
-                    metadata["analysis"]["info"][
-                        f"{name_object}"
-                    ] = _create_nested_metadata(analysis_to_parse)
-=======
                     data_to_parse = json.loads(f.read())
->>>>>>> fw/main
                 except json.decoder.JSONDecodeError:
                     log.info(f"{analysis} was empty")
                     continue
@@ -161,6 +146,3 @@ def _create_nested_metadata(data_to_parse):
     # Should be roughly 68 metrics. See https://mriqc.readthedocs.io/en/latest/measures.html
     log.debug(f"Passing {len(add_metadata)} IQM items to metadata.")
     return add_metadata
-
-
-

--- a/utils/results/zip_htmls.py
+++ b/utils/results/zip_htmls.py
@@ -36,7 +36,6 @@ def zip_htmls(context, path):
     log.info("Creating viewable archives for all html files")
 
     if os.path.exists(path):
-
         log.info("Found path: " + str(path))
 
         os.chdir(path)
@@ -44,7 +43,6 @@ def zip_htmls(context, path):
         html_files = glob.glob("*.html")
 
         if len(html_files) > 0:
-
             # if there is an index.html, do it first and re-name it for safe
             # keeping
             save_name = ""
@@ -71,5 +69,4 @@ def zip_htmls(context, path):
             log.warning("No *.html files at " + str(path))
 
     else:
-
         log.error("Path NOT found: " + str(path))

--- a/utils/results/zip_intermediate.py
+++ b/utils/results/zip_intermediate.py
@@ -30,7 +30,6 @@ def zip_intermediate_selected(context, run_label):
             do_find = True
 
     if do_find:
-
         # Name of zip file has <subject> and <analysis>
         analysis_id = context.destination["id"]
         gear_name = context.manifest["name"]
@@ -44,7 +43,6 @@ def zip_intermediate_selected(context, run_label):
         files_found = []
         folders_found = []
         for subdir, walk_dirs, walk_files in os.walk("."):
-
             for ff in walk_files:
                 if ff in files:
                     path = os.path.join(subdir, ff)


### PR DESCRIPTION
Attempt to merge the latest version of the Flywheel release (1.2.4_0.15.2)
- Changes the IQMs to file.info['IQM']
- some variable refactoring and log handling
- (sorry) puts a few new lines back in b/c of auto-merge